### PR TITLE
Feat: configurable menu width

### DIFF
--- a/EasySpawner/Config/EasySpawnerConfig.cs
+++ b/EasySpawner/Config/EasySpawnerConfig.cs
@@ -15,6 +15,7 @@ namespace EasySpawner.Config
         public ConfigEntry<string> SecondSpawnHotkey;
         public ConfigEntry<string> UndoHotkey;
         public ConfigEntry<string> UndoHotkeyModifier;
+        public ConfigEntry<float> UIWidth;
 
         public bool OpenHotkeyModifierSet;
         public bool SpawnHotkeyModifierSet;
@@ -32,6 +33,8 @@ namespace EasySpawner.Config
 
             UndoHotkey = ConfigFile.Bind("Hotkeys", "UndoHotkey", "z", "Hotkey to Undo last spawn");
             UndoHotkeyModifier = ConfigFile.Bind("Hotkeys", "UndoHotkeyModifier", "left ctrl", "Modifier to Undo hotkey");
+
+            UIWidth = ConfigFile.Bind("UI", "MenuWidth", 450f, "Width of the menu");
 
             FirstOpenHotkey.Value = FirstOpenHotkey.Value.ToLower();
             FirstOpenHotkeyModifier.Value = FirstOpenHotkeyModifier.Value.ToLower();

--- a/EasySpawner/EasySpawner.csproj
+++ b/EasySpawner/EasySpawner.csproj
@@ -49,8 +49,8 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\0Harmony.dll</HintPath>
-      <HintPath>$(R2MODMAN_INSTALL)\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(VALHEIM_INSTALL)\BepInEx\core\0Harmony.dll')">$(VALHEIM_INSTALL)\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(R2MODMAN_INSTALL)\BepInEx\core\0Harmony.dll')">$(R2MODMAN_INSTALL)\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="assembly_utils, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>$(VALHEIM_INSTALL)\valheim_Data\Managed\assembly_utils.dll</HintPath>
@@ -62,12 +62,12 @@
       <HintPath>$(VALHEIM_INSTALL)\valheim_Data\Managed\assembly_valheim.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.dll</HintPath>
-      <HintPath>$(R2MODMAN_INSTALL)\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath Condition="Exists('$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.dll')">$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath Condition="Exists('$(R2MODMAN_INSTALL)\BepInEx\core\BepInEx.dll')">$(R2MODMAN_INSTALL)\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx.Harmony">
-      <HintPath>$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.Harmony.dll</HintPath>
-      <HintPath>$(R2MODMAN_INSTALL)\BepInEx\core\BepInEx.Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.Harmony.dll')">$(VALHEIM_INSTALL)\BepInEx\core\BepInEx.Harmony.dll</HintPath>
+      <HintPath Condition="Exists('$(R2MODMAN_INSTALL)\BepInEx\core\BepInEx.Harmony.dll')">$(R2MODMAN_INSTALL)\BepInEx\core\BepInEx.Harmony.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/EasySpawner/UI/EasySpawnerMenu.cs
+++ b/EasySpawner/UI/EasySpawnerMenu.cs
@@ -69,6 +69,9 @@ namespace EasySpawner.UI
             else
                 CloseText.text = "Open: " + config.FirstOpenHotkey.Value;
 
+            UpdateMenuSize();
+            config.UIWidth.SettingChanged += (sender, e) => UpdateMenuSize();
+
             //Initial player dropdown
             PlayerDropdown.ClearOptions();
             RebuildPlayerDropdown();
@@ -89,6 +92,12 @@ namespace EasySpawner.UI
 
             PrefabScrollView.onValueChanged.AddListener(UpdateItemPrefabPool);
             RebuildPrefabDropdown();
+        }
+
+        private void UpdateMenuSize()
+        {
+            RectTransform menuRect = (RectTransform) EasySpawnerPlugin.menuGameObject.transform;
+            menuRect.sizeDelta = new Vector2(EasySpawnerPlugin.config.UIWidth.Value, menuRect.sizeDelta.y);
         }
 
         public void PoolPrefabItem(PrefabItem item)

--- a/EasySpawner/UI/EasySpawnerMenu.cs
+++ b/EasySpawner/UI/EasySpawnerMenu.cs
@@ -69,8 +69,8 @@ namespace EasySpawner.UI
             else
                 CloseText.text = "Open: " + config.FirstOpenHotkey.Value;
 
-            UpdateMenuSize();
-            config.UIWidth.SettingChanged += (sender, e) => UpdateMenuSize();
+            UpdateMenuSize(null, null);
+            config.UIWidth.SettingChanged += UpdateMenuSize;
 
             //Initial player dropdown
             PlayerDropdown.ClearOptions();
@@ -94,7 +94,7 @@ namespace EasySpawner.UI
             RebuildPrefabDropdown();
         }
 
-        private void UpdateMenuSize()
+        private void UpdateMenuSize(object sender, EventArgs e)
         {
             RectTransform menuRect = (RectTransform) EasySpawnerPlugin.menuGameObject.transform;
             menuRect.sizeDelta = new Vector2(EasySpawnerPlugin.config.UIWidth.Value, menuRect.sizeDelta.y);
@@ -271,6 +271,7 @@ namespace EasySpawner.UI
             SpawnButton.onClick.RemoveAllListeners();
             PrefabItems = null;
             PrefabItemPool = new Queue<PrefabItem>();
+            EasySpawnerPlugin.config.UIWidth.SettingChanged -= UpdateMenuSize;
         }
     }
 }

--- a/EasySpawner/UI/UIElementDragger.cs
+++ b/EasySpawner/UI/UIElementDragger.cs
@@ -5,48 +5,34 @@ namespace EasySpawner.UI
 {
 	public class UIElementDragger : MonoBehaviour, IDragHandler, IBeginDragHandler
 	{
-		private Vector2 lastMousePosition;
+		private RectTransform window;
+		private Vector2 delta;
+
+		private void Awake()
+		{
+			window = (RectTransform)transform;
+		}
 
 		public void OnBeginDrag(PointerEventData eventData)
 		{
-			lastMousePosition = eventData.position;
+			delta = Input.mousePosition - window.position;
 		}
 
 		public void OnDrag(PointerEventData eventData)
 		{
-			Vector2 currentMousePosition = eventData.position;
-			Vector2 diff = currentMousePosition - lastMousePosition;
-			RectTransform rect = GetComponent<RectTransform>();
+			Vector2 pos = eventData.position - delta;
+			Rect rect = window.rect;
+			Vector2 lossyScale = window.lossyScale;
 
-			Vector3 newPosition = rect.position + new Vector3(diff.x, diff.y, transform.position.z);
-			Vector3 oldPos = rect.position;
-			rect.position = newPosition;
-			if (!IsRectTransformInsideSreen(rect))
-			{
-				rect.position = oldPos;
-			}
-			lastMousePosition = currentMousePosition;
-		}
+			float minX = rect.width / 2f * lossyScale.x;
+			float maxX = Screen.width - minX;
+			float minY = rect.height / 2f * lossyScale.y;
+			float maxY = Screen.height - minY;
 
-		private bool IsRectTransformInsideSreen(RectTransform rectTransform)
-		{
-			bool isInside = false;
-			Vector3[] corners = new Vector3[4];
-			rectTransform.GetWorldCorners(corners);
-			int visibleCorners = 0;
-			Rect rect = new Rect(0, 0, Screen.width, Screen.height);
-			foreach (Vector3 corner in corners)
-			{
-				if (rect.Contains(corner))
-				{
-					visibleCorners++;
-				}
-			}
-			if (visibleCorners == 4)
-			{
-				isInside = true;
-			}
-			return isInside;
+			pos.x = Mathf.Clamp(pos.x, minX, maxX);
+			pos.y = Mathf.Clamp(pos.y, minY, maxY);
+
+			transform.position = pos;
 		}
 	}
 }


### PR DESCRIPTION
Hi, this small update adds a config option to set the menu width as it sometimes was too small to display names. It also works at runtime, so changes via a config manager are instantly applied.

I've also fixed the dragger as it behaved weirdly on the screen borders.

![easyspawnerwidth](https://user-images.githubusercontent.com/39767545/184240840-42c8e294-4aad-4def-9500-f2f34dde1a37.png)
